### PR TITLE
feat: AsyncEval codegen support

### DIFF
--- a/phew/emit/codegen.py
+++ b/phew/emit/codegen.py
@@ -54,6 +54,7 @@ class MLXCodegen:
 
     def _emit_body(self, graph: "Graph") -> list[str]:
         from phew.ir import (
+            AsyncEval,
             Cast,
             Compile,
             Concat,
@@ -235,6 +236,15 @@ class MLXCodegen:
             elif isinstance(node, Compile):
                 # Handled at function level via @mx.compile decorator; pass through
                 vname = ins[0] if ins else fresh("compiled")
+                name_map[node.id] = vname
+                continue
+
+            elif isinstance(node, AsyncEval):
+                # mx.async_eval schedules evaluation without blocking, overlapping
+                # CPU work with GPU execution. Pass-through: the output array
+                # reference is unchanged; the async_eval call is a side effect.
+                vname = ins[0] if ins else fresh("async")
+                lines.append(f"mx.async_eval({', '.join(ins)})")
                 name_map[node.id] = vname
                 continue
 

--- a/phew/emit/codegen.py
+++ b/phew/emit/codegen.py
@@ -25,7 +25,7 @@ class MLXCodegen:
 
     def emit(self, graph: "Graph", fn_name: str = "optimized") -> str:
         """Return Python source string for the optimized function."""
-        from phew.ir import Compile, Input
+        from phew.ir import Compile
 
         lines: list[str] = []
         lines.append("import mlx.core as mx")

--- a/phew/rules/primitive_subst.py
+++ b/phew/rules/primitive_subst.py
@@ -287,7 +287,15 @@ class PrimitiveSubstPass:
 
     def _match_sdpa(self, graph: "Graph") -> bool:
         """Match softmax(Q @ K^T * scale) @ V → FastScaledDotProductAttention."""
-        from phew.ir import Cast, Constant, Elementwise, FastScaledDotProductAttention, MatMul, Reduce, Transpose
+        from phew.ir import (
+            Cast,
+            Constant,
+            Elementwise,
+            FastScaledDotProductAttention,
+            MatMul,
+            Reduce,
+            Transpose,
+        )
 
         changed = False
 

--- a/phew/verify/checker.py
+++ b/phew/verify/checker.py
@@ -168,6 +168,7 @@ class EquivalenceChecker:
                             tol = self.tolerance
                             if is_bf16:
                                 from .tolerances import Tolerance
+
                                 out_mean = float(np.mean(np.abs(b_np)))
                                 # Relax tolerance proportionally for extreme outputs
                                 # (large_scale variant with 1e6 inputs → ~1e21 outputs)


### PR DESCRIPTION
## Summary
- `MLXCodegen._emit_body()` now handles `AsyncEval` nodes, emitting `mx.async_eval(...)` as a side-effect statement and passing through the array reference unchanged
- Enables the existing `AsyncEval` IR node to produce runnable output code, overlapping CPU work with GPU evaluation in loops

## Test plan
- All 25 existing tests pass