### PR TITLE
feat: AlgebraicPass — dead cast/transpose/reshape elimination

### DIFF
--- a/phew/emit/codegen.py
+++ b/phew/emit/codegen.py
@@ -25,7 +25,7 @@ class MLXCodegen:
 
     def emit(self, graph: "Graph", fn_name: str = "optimized") -> str:
         """Return Python source string for the optimized function."""
-        from phew.ir import Compile, Input
+        from phew.ir import Compile
 
         lines: list[str] = []
         lines.append("import mlx.core as mx")

--- a/phew/rules/__init__.py
+++ b/phew/rules/__init__.py
@@ -9,6 +9,7 @@ All other rules (algebraic, fusion, layout, precision, quantization) operate
 inside the egglog e-graph via phew/egraph/rules_egglog.py.
 """
 
+from .algebraic import AlgebraicPass
 from .compile_boundaries import CompileBoundaryPass
 from .fusion import ElementwiseFusionPass
 from .graph_passes import run_all_passes
@@ -16,6 +17,7 @@ from .primitive_subst import PrimitiveSubstPass
 from .tensorops import TensorOpsPass
 
 __all__ = [
+    "AlgebraicPass",
     "PrimitiveSubstPass",
     "CompileBoundaryPass",
     "ElementwiseFusionPass",

--- a/phew/rules/algebraic.py
+++ b/phew/rules/algebraic.py
@@ -1,0 +1,157 @@
+"""Algebraic simplification pass — operates directly on phew.ir.Graph.
+
+Rewrites applied (in order, iterated until fixed point):
+  1. No-op cast removal:       cast(x, x.dtype)              → x
+  2. Double-cast elimination:  cast(cast(x, A), B)            → cast(x, B)
+  3. Transpose cancellation:   transpose(transpose(x,p), q)   → x  if p∘q = id
+  4. Reshape of reshape:       reshape(reshape(x, s1), s2)    → reshape(x, s2)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from phew.ir.graph import Graph
+    from phew.ir.node import Node, NodeId
+
+
+def _compose_axes(outer: tuple[int, ...], inner: tuple[int, ...]) -> tuple[int, ...]:
+    """Compose two permutations: result[i] = inner[outer[i]]."""
+    return tuple(inner[outer[i]] for i in range(len(outer)))
+
+
+def _is_identity(axes: tuple[int, ...]) -> bool:
+    return axes == tuple(range(len(axes)))
+
+
+class AlgebraicPass:
+    """Algebraic simplification pass.
+
+    Rewrites:
+    - No-op cast removal: cast(x, x.dtype) → x
+    - Double-cast elimination: cast(cast(x, A), B) → cast(x, B)
+    - Transpose cancellation: transpose(transpose(x, p), q) → x when p∘q = identity
+    - Reshape of reshape: reshape(reshape(x, s1), s2) → reshape(x, s2)
+    """
+
+    def run(self, graph: "Graph") -> "Graph":
+        """Apply rewrites to *graph* until fixed point. Returns graph."""
+        changed = True
+        while changed:
+            changed = self._one_pass(graph)
+        return graph
+
+    def _one_pass(self, graph: "Graph") -> bool:
+        from phew.ir.ops import Cast, Reshape, Transpose
+
+        for node in graph.topo_order():
+            if isinstance(node, Cast) and self._rewrite_cast(node, graph):
+                return True
+            if isinstance(node, Transpose) and self._rewrite_transpose(node, graph):
+                return True
+            if isinstance(node, Reshape) and self._rewrite_reshape(node, graph):
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Cast
+    # ------------------------------------------------------------------
+
+    def _rewrite_cast(self, node: "Node", graph: "Graph") -> bool:
+        from phew.ir.ops import Cast
+
+        if not node.inputs:
+            return False
+        inp_id: "NodeId" = node.inputs[0]
+        if inp_id not in graph:
+            return False
+        inp = graph[inp_id]
+
+        # Rule 1: no-op cast
+        if node.target_dtype == inp.dtype:
+            self._redirect(node.id, inp_id, graph)
+            graph.remove(node.id)
+            return True
+
+        # Rule 2: double-cast — cast(cast(x, A), B) → cast(x, B)
+        if isinstance(inp, Cast) and inp.inputs:
+            inner_inp_id = inp.inputs[0]
+            if inner_inp_id not in graph:
+                return False
+            node.inputs = [inner_inp_id]
+            if not graph.successors(inp.id):
+                graph.remove(inp.id)
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Transpose
+    # ------------------------------------------------------------------
+
+    def _rewrite_transpose(self, node: "Node", graph: "Graph") -> bool:
+        from phew.ir.ops import Transpose
+
+        if not node.inputs:
+            return False
+        inp_id = node.inputs[0]
+        if inp_id not in graph:
+            return False
+        inp = graph[inp_id]
+
+        if not isinstance(inp, Transpose) or not inp.inputs:
+            return False
+
+        outer = node.axes
+        inner = inp.axes
+        if not outer or not inner or len(outer) != len(inner):
+            return False
+
+        composed = _compose_axes(outer, inner)
+        if _is_identity(composed):
+            inner_inp_id = inp.inputs[0]
+            self._redirect(node.id, inner_inp_id, graph)
+            graph.remove(node.id)
+            if not graph.successors(inp.id):
+                graph.remove(inp.id)
+            return True
+
+        return False
+
+    # ------------------------------------------------------------------
+    # Reshape
+    # ------------------------------------------------------------------
+
+    def _rewrite_reshape(self, node: "Node", graph: "Graph") -> bool:
+        from phew.ir.ops import Reshape
+
+        if not node.inputs:
+            return False
+        inp_id = node.inputs[0]
+        if inp_id not in graph:
+            return False
+        inp = graph[inp_id]
+
+        if not isinstance(inp, Reshape) or not inp.inputs:
+            return False
+
+        inner_inp_id = inp.inputs[0]
+        if inner_inp_id not in graph:
+            return False
+        inner_inp = graph[inner_inp_id]
+
+        node.inputs = [inner_inp_id]
+        node.input_shape = inner_inp.shape
+        if not graph.successors(inp.id):
+            graph.remove(inp.id)
+        return True
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _redirect(self, old_id: "NodeId", new_id: "NodeId", graph: "Graph") -> None:
+        for n in graph.nodes():
+            n.inputs = [new_id if i == old_id else i for i in n.inputs]
+        graph.outputs = [new_id if o == old_id else o for o in graph.outputs]

--- a/phew/rules/graph_passes.py
+++ b/phew/rules/graph_passes.py
@@ -24,14 +24,24 @@ def run_all_passes(
     enable_primitive_subst: bool = True,
     enable_tensorops: bool = True,
     enable_fusion: bool = False,
+    enable_algebraic: bool = True,
 ) -> tuple["Graph", list[str]]:
     """Run graph-level passes. Return (graph, list_of_applied_pass_names)."""
+    from .algebraic import AlgebraicPass
     from .compile_boundaries import CompileBoundaryPass
     from .fusion import ElementwiseFusionPass
     from .primitive_subst import PrimitiveSubstPass
     from .tensorops import TensorOpsPass
 
     applied: list[str] = []
+
+    # Algebraic simplification runs first: eliminates redundant casts/transposes/reshapes
+    # before other passes run, reducing graph size and improving pattern matching.
+    if enable_algebraic:
+        before = len(graph)
+        AlgebraicPass().run(graph)
+        if len(graph) != before:
+            applied.append("algebraic")
 
     if enable_fusion:
         if ElementwiseFusionPass().run(graph):

--- a/phew/rules/primitive_subst.py
+++ b/phew/rules/primitive_subst.py
@@ -287,7 +287,15 @@ class PrimitiveSubstPass:
 
     def _match_sdpa(self, graph: "Graph") -> bool:
         """Match softmax(Q @ K^T * scale) @ V → FastScaledDotProductAttention."""
-        from phew.ir import Cast, Constant, Elementwise, FastScaledDotProductAttention, MatMul, Reduce, Transpose
+        from phew.ir import (
+            Cast,
+            Constant,
+            Elementwise,
+            FastScaledDotProductAttention,
+            MatMul,
+            Reduce,
+            Transpose,
+        )
 
         changed = False
 

--- a/phew/verify/checker.py
+++ b/phew/verify/checker.py
@@ -168,6 +168,7 @@ class EquivalenceChecker:
                             tol = self.tolerance
                             if is_bf16:
                                 from .tolerances import Tolerance
+
                                 out_mean = float(np.mean(np.abs(b_np)))
                                 # Relax tolerance proportionally for extreme outputs
                                 # (large_scale variant with 1e6 inputs → ~1e21 outputs)


### PR DESCRIPTION
## Summary
- New `phew/rules/algebraic.py` with `AlgebraicPass` implementing four algebraic simplifications that iterate to fixed point:
  1. No-op cast removal: `cast(x, x.dtype) → x`
  2. Double-cast elimination: `cast(cast(x, A), B) → cast(x, B)`
  3. Transpose cancellation: `transpose(transpose(x, p), q) → x` when `p∘q = id`
  4. Reshape of reshape: `reshape(reshape(x, s1), s2) → reshape(x, s2)`
- `AlgebraicPass` runs first in `run_all_passes()` (opt-out via `enable_algebraic=False`) to reduce graph size before pattern matching

## Test plan
- All 25 existing tests pass