### PR TITLE
feat: PrecisionPass and QuantizationPass as opt-in graph passes

### DIFF
--- a/phew/rules/__init__.py
+++ b/phew/rules/__init__.py
@@ -13,14 +13,18 @@ from .algebraic import AlgebraicPass
 from .compile_boundaries import CompileBoundaryPass
 from .fusion import ElementwiseFusionPass
 from .graph_passes import run_all_passes
+from .precision import PrecisionPass
 from .primitive_subst import PrimitiveSubstPass
+from .quantization import QuantizationPass
 from .tensorops import TensorOpsPass
 
 __all__ = [
     "AlgebraicPass",
+    "PrecisionPass",
     "PrimitiveSubstPass",
     "CompileBoundaryPass",
     "ElementwiseFusionPass",
+    "QuantizationPass",
     "TensorOpsPass",
     "run_all_passes",
 ]

--- a/phew/rules/graph_passes.py
+++ b/phew/rules/graph_passes.py
@@ -5,8 +5,12 @@ Search prior (highest-yield first):
   2. Primitive substitution (PrimitiveSubstPass) — fast.* matches end search
   3. TensorOps (TensorOpsPass) — hardware-gated
 
-Egglog rules (algebraic/fusion/layout/precision/quant) run inside the
-EGraphSaturator after these graph passes complete.
+Opt-in passes (require explicit enable_*=True):
+  - PrecisionPass: fp32 → bf16 (halves bandwidth, ~2× for memory-bound graphs)
+  - QuantizationPass: MatMul → QuantizedMatMul (4-bit weights)
+
+Egglog rules (algebraic/fusion/layout) run inside the EGraphSaturator after
+these graph passes complete.
 """
 
 from __future__ import annotations
@@ -25,12 +29,33 @@ def run_all_passes(
     enable_tensorops: bool = True,
     enable_fusion: bool = False,
     enable_algebraic: bool = True,
+    enable_precision: bool = False,
+    enable_quantization: bool = False,
+    precision_dtype=None,
+    quantization_bits: int = 4,
+    quantization_group_size: int = 64,
 ) -> tuple["Graph", list[str]]:
-    """Run graph-level passes. Return (graph, list_of_applied_pass_names)."""
+    """Run graph-level passes. Return (graph, list_of_applied_pass_names).
+
+    Opt-in parameters
+    -----------------
+    enable_precision:
+        Insert fp32→bf16 casts at inputs and bf16→fp32 casts at outputs.
+        Halves memory bandwidth for activation tensors.
+    enable_quantization:
+        Replace MatMul(x, W) with QuantizedMatMul when W is a parameter/constant.
+    precision_dtype:
+        Target dtype for PrecisionPass. Defaults to Dtype.bfloat16.
+    quantization_bits:
+        Bit-width for QuantizationPass (4 or 8). Default 4.
+    quantization_group_size:
+        Group size for group-wise quantization. Default 64.
+    """
     from .algebraic import AlgebraicPass
     from .compile_boundaries import CompileBoundaryPass
     from .fusion import ElementwiseFusionPass
     from .primitive_subst import PrimitiveSubstPass
+    from .quantization import QuantizationPass
     from .tensorops import TensorOpsPass
 
     applied: list[str] = []
@@ -42,6 +67,19 @@ def run_all_passes(
         AlgebraicPass().run(graph)
         if len(graph) != before:
             applied.append("algebraic")
+
+    # Opt-in: precision reduction (fp32 → bf16) — do this first so subsequent
+    # passes see the reduced-precision graph and can make better decisions.
+    if enable_precision:
+        from phew.ir.dtype import Dtype  # noqa: PLC0415
+
+        from .precision import PrecisionPass  # noqa: PLC0415
+
+        target = precision_dtype or Dtype.bfloat16
+        before = len(graph)
+        PrecisionPass(target_dtype=target).run(graph)
+        if len(graph) != before:
+            applied.append("precision")
 
     if enable_fusion:
         if ElementwiseFusionPass().run(graph):
@@ -56,6 +94,14 @@ def run_all_passes(
             applied.append("primitive_subst")
             # Primitive subst ends Phase-1 for matched subgraphs — no eggsat needed
             return graph, applied
+
+    # Opt-in: 4-bit quantization — run after primitive_subst so we don't
+    # quantize matmuls that were already replaced with fast.* ops.
+    if enable_quantization:
+        before = len(graph)
+        QuantizationPass(bits=quantization_bits, group_size=quantization_group_size).run(graph)
+        if len(graph) != before:
+            applied.append("quantization")
 
     if enable_tensorops:
         if TensorOpsPass().run(graph):

--- a/phew/rules/precision.py
+++ b/phew/rules/precision.py
@@ -1,0 +1,87 @@
+"""PrecisionPass: opt-in fp32 → bf16/fp16 promotion.
+
+Inserts Cast nodes at graph inputs and a Cast back to fp32 at graph outputs
+when the user opts into a reduced-precision substitution class.
+
+This halves memory bandwidth for activation tensors and is the #2 highest-yield
+optimization after mx.compile (from the search prior in CLAUDE.md).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from phew.ir.graph import Graph
+
+from phew.ir.dtype import Dtype
+
+
+class PrecisionPass:
+    """Opt-in fp32 → bf16 (or fp16) precision reduction.
+
+    Inserts Cast(x, target_dtype) after each fp32 Input node and a Cast back
+    to float32 before each graph output that was originally fp32, so the
+    function signature is unchanged but internal activations run at lower
+    precision.
+
+    Parameters
+    ----------
+    target_dtype:
+        Target reduced-precision dtype. Defaults to bfloat16 (recommended for
+        Apple Silicon; better dynamic range than fp16).
+    """
+
+    def __init__(self, target_dtype: Dtype = Dtype.bfloat16) -> None:
+        self.target_dtype = target_dtype
+
+    def run(self, graph: "Graph") -> "Graph":
+        """Mutate *graph* in place. Returns graph."""
+        from phew.ir.ops import Cast, Input
+
+        # Step 1: insert downcast after each fp32 Input
+        for node in list(graph.topo_order()):
+            if not isinstance(node, Input):
+                continue
+            if node.dtype != Dtype.float32:
+                continue
+
+            cast_down = Cast(
+                shape=node.shape,
+                dtype=self.target_dtype,
+                inputs=[node.id],
+                target_dtype=self.target_dtype,
+            )
+            graph.add(cast_down)
+
+            # Redirect all consumers of this Input (except cast_down itself)
+            for n in graph.nodes():
+                if n.id == cast_down.id:
+                    continue
+                n.inputs = [cast_down.id if i == node.id else i for i in n.inputs]
+
+            # Update graph outputs that pointed directly at the Input
+            graph.outputs = [cast_down.id if o == node.id else o for o in graph.outputs]
+
+        # Step 2: insert upcast back to fp32 at each graph output that is now
+        # reduced-precision, to preserve the original function's output dtype.
+        new_outputs = []
+        for out_id in graph.outputs:
+            if out_id not in graph:
+                new_outputs.append(out_id)
+                continue
+            out_node = graph[out_id]
+            if out_node.dtype == self.target_dtype:
+                cast_up = Cast(
+                    shape=out_node.shape,
+                    dtype=Dtype.float32,
+                    inputs=[out_id],
+                    target_dtype=Dtype.float32,
+                )
+                graph.add(cast_up)
+                new_outputs.append(cast_up.id)
+            else:
+                new_outputs.append(out_id)
+        graph.outputs = new_outputs
+
+        return graph

--- a/phew/rules/quantization.py
+++ b/phew/rules/quantization.py
@@ -1,0 +1,73 @@
+"""QuantizationPass: opt-in 4-bit weight quantization.
+
+Replaces MatMul(x, W) with QuantizedMatMul(x, W, bits=4, group_size=64)
+when the weight operand is a parameter (Input with is_parameter=True in attrs)
+or a Constant node. Requires explicit opt-in.
+
+From the search prior (CLAUDE.md): #4 highest-yield — nn.quantize(bits=4)
+for matmul-heavy graphs, after mx.compile and fast.* primitives.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from phew.ir.graph import Graph
+
+
+class QuantizationPass:
+    """Opt-in 4-bit weight quantization.
+
+    Replaces MatMul(x, W) with QuantizedMatMul(x, W, bits=bits, group_size=group_size)
+    when the weight (second operand) is a parameter or constant.
+
+    Parameters
+    ----------
+    bits:
+        Quantization bit-width. 4 (default) or 8.
+    group_size:
+        Group size for group-wise quantization. Default 64.
+    """
+
+    def __init__(self, bits: int = 4, group_size: int = 64) -> None:
+        self.bits = bits
+        self.group_size = group_size
+
+    def run(self, graph: "Graph") -> "Graph":
+        """Mutate *graph* in place. Returns graph."""
+        from phew.ir.ops import Constant, Input, MatMul, QuantizedMatMul
+
+        changed = False
+        for node in list(graph.topo_order()):
+            if not isinstance(node, MatMul):
+                continue
+            if len(node.inputs) < 2:
+                continue
+
+            weight_id = node.inputs[1]
+            if weight_id not in graph:
+                continue
+            weight_node = graph[weight_id]
+
+            # Only quantize when weight is a parameter or constant —
+            # activations change every forward pass and can't be pre-quantized.
+            is_param = (
+                isinstance(weight_node, Input)
+                and bool(weight_node.attrs.get("is_parameter", False))
+            ) or isinstance(weight_node, Constant)
+
+            if not is_param:
+                continue
+
+            qmatmul = QuantizedMatMul(
+                shape=node.shape,
+                dtype=node.dtype,
+                inputs=list(node.inputs),
+                bits=self.bits,
+                group_size=self.group_size,
+            )
+            graph.replace(node.id, qmatmul)
+            changed = True
+
+        return graph

--- a/phew/rules/quantization.py
+++ b/phew/rules/quantization.py
@@ -38,7 +38,6 @@ class QuantizationPass:
         """Mutate *graph* in place. Returns graph."""
         from phew.ir.ops import Constant, Input, MatMul, QuantizedMatMul
 
-        changed = False
         for node in list(graph.topo_order()):
             if not isinstance(node, MatMul):
                 continue
@@ -68,6 +67,5 @@ class QuantizationPass:
                 group_size=self.group_size,
             )
             graph.replace(node.id, qmatmul)
-            changed = True
 
         return graph


### PR DESCRIPTION
## Summary
- `PrecisionPass` (new `phew/rules/precision.py`): inserts `Cast(fp32→bf16)` after fp32 Input nodes and `Cast(bf16→fp32)` before graph outputs, halving activation bandwidth. Opt-in via `enable_precision=True`.
- `QuantizationPass` (new `phew/rules/quantization.py`): replaces `MatMul(x, W)` with `QuantizedMatMul(x, W, bits=4, group_size=64)` when `W` is a parameter or constant. Opt-in via `enable_quantization=True`.
- Both passes are strictly opt-in (not enabled by default). `run_all_passes()` gains `enable_precision`, `enable_quantization`, `precision_dtype`, `quantization_bits`, and `quantization_group_size` parameters.

## Test plan
- All 25 existing tests pass