### PR TITLE
feat: .metal file support (lint + wrap)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.0
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^(phew|tests|examples)/
+      - id: ruff-format
+        files: ^(phew|tests|examples)/

--- a/README.md
+++ b/README.md
@@ -85,16 +85,21 @@ phew bench  input.py                # baseline benchmark only
 phew trace  input.py                # capture Metal GPU trace
 phew verify baseline.py opt.py      # verify equivalence standalone
 phew lint   path/                   # scan for inefficiency patterns (no harness needed)
+phew metal  list kernel.metal       # list all [[kernel]] functions
+phew metal  wrap kernel.metal       # generate mx.fast.metal_kernel wrappers
 ```
 
 ### phew lint
 
-Scans Python files statically for known MLX inefficiencies. No `input_factory`, no execution — just point it at a file or directory.
+Scans Python and `.metal` files statically for known inefficiencies. No `input_factory`, no execution — just point it at a file or directory.
 
 ```
 phew lint mlx_lm/models/
 phew lint model.py -r rms_norm,sdpa   # filter to specific rules
+phew lint kernels.metal               # Metal rules apply automatically
 ```
+
+**Python rules:**
 
 | Rule | Pattern | Suggestion |
 |---|---|---|
@@ -103,7 +108,16 @@ phew lint model.py -r rms_norm,sdpa   # filter to specific rules
 | `sdpa` | `softmax(Q @ K.T * s) @ V` | `mx.fast.scaled_dot_product_attention(Q, K, V, scale=s)` |
 | `compile` | standalone mx-op function, no `@mx.compile` | add `@mx.compile` |
 
-Catches inline single-expression patterns. Split-assignment form (`rsqrt = mx.rsqrt(...); result = (x @ W) * rsqrt`) requires the full optimizer.
+**Metal rules (`.metal` files):**
+
+| Rule | Pattern | Suggestion |
+|---|---|---|
+| `max_threads` | kernel missing `[[max_total_threads_per_threadgroup(N)]]` | add attribute to guide register allocation |
+| `missing_simd_reduce` | threadgroup barrier reduction without `simd_sum` first pass | `acc = simd_sum(acc)` before writing to threadgroup memory |
+| `half_accumulator` | scalar `half` local used as accumulator | use `float`; convert to `half` on store only |
+| `unvectorized_loop` | strided loop over `half*` reading one element at a time | use `half4` loads for 4× bandwidth |
+
+Catches inline single-expression patterns in Python. Split-assignment form requires the full optimizer. Metal rules operate on the kernel body directly.
 
 ---
 

--- a/phew/SKILL.md
+++ b/phew/SKILL.md
@@ -1,15 +1,16 @@
 # phew skill — optimize MLX kernels on Apple Silicon
 
-PHEW is a search-based superoptimizer for MLX/Metal. It finds verified-equivalent rewrites of your MLX Python functions that are measurably faster on device.
+PHEW is an optimizer for MLX/Metal. It finds verified-equivalent rewrites of your MLX Python functions that are measurably faster on device. It also statically scans Python and `.metal` files for known inefficiency patterns.
 
 ## Quick scan (no harness required)
 
 ```bash
-phew lint path/to/model.py          # scan for known patterns
+phew lint path/to/model.py          # scan Python files for known patterns
 phew lint src/ --rule compile       # filter to one rule
+phew lint kernels.metal             # scan a .metal file
 ```
 
-Rules caught by lint:
+**Python rules:**
 
 | Rule | Pattern detected |
 |------|-----------------|
@@ -17,6 +18,15 @@ Rules caught by lint:
 | `normed_matmul` | `(x @ W) * rsqrt(mean(x²) + eps)` → `mx.fast.rms_norm(x, None) @ W` |
 | `sdpa` | `softmax(Q @ K.T * s) @ V` → `mx.fast.scaled_dot_product_attention` |
 | `compile` | mx-op function missing `@mx.compile` |
+
+**Metal rules (`.metal` files):**
+
+| Rule | Pattern detected |
+|------|-----------------|
+| `max_threads` | kernel missing `[[max_total_threads_per_threadgroup(N)]]` |
+| `missing_simd_reduce` | threadgroup barrier reduction without `simd_sum` first pass |
+| `half_accumulator` | scalar `half` local used as accumulator instead of `float` |
+| `unvectorized_loop` | strided loop over `half*` reading scalarly instead of `half4` |
 
 Apply lint hits manually or hand them to the optimizer.
 
@@ -97,6 +107,19 @@ phew run my_kernel.py --trace phew_trace.gputrace  # use existing trace
 ```
 
 Trace is optional but improves rule pruning (bottleneck-driven search).
+
+## .metal files
+
+```bash
+phew metal list kernels.metal           # list all [[kernel]] functions and arg counts
+phew metal wrap kernels.metal           # generate mx.fast.metal_kernel Python wrappers
+phew metal wrap kernels.metal -k gemv   # wrap a single kernel by name
+phew metal wrap kernels.metal -o harness.py
+```
+
+`phew metal wrap` generates a Python harness with `mx.fast.metal_kernel` objects and stub wrapper functions. Review all `# TODO` comments before use — constant scalar args (`constant T &x`) need to be packed into a struct buffer or baked as template constants, and grid/threadgroup dimensions must be set for your problem size.
+
+Once wrapped, feed the harness into `phew run` for Phase-2 threadgroup parameter search.
 
 ## Verify a hand-written optimization
 

--- a/phew/cli/main.py
+++ b/phew/cli/main.py
@@ -525,9 +525,8 @@ def lint(path, rule):
         from rich.markup import escape
 
         color = rule_colors.get(issue.rule, "white")
-        console.print(
-            f"  [dim]{issue.line:>4}[/dim]  [{color}]{issue.rule:<16}[/{color}]  {escape(issue.message)}"
-        )
+        msg = escape(issue.message)
+        console.print(f"  [dim]{issue.line:>4}[/dim]  [{color}]{issue.rule:<16}[/{color}]  {msg}")
 
     total = len(issues)
     rule_counts: dict[str, int] = {}

--- a/phew/cli/main.py
+++ b/phew/cli/main.py
@@ -522,9 +522,11 @@ def lint(path, rule):
         if issue.file != current_file:
             current_file = issue.file
             console.print(f"\n[bold]{issue.file}[/bold]")
+        from rich.markup import escape
+
         color = rule_colors.get(issue.rule, "white")
         console.print(
-            f"  [dim]{issue.line:>4}[/dim]  [{color}]{issue.rule:<16}[/{color}]  {issue.message}"
+            f"  [dim]{issue.line:>4}[/dim]  [{color}]{issue.rule:<16}[/{color}]  {escape(issue.message)}"
         )
 
     total = len(issues)

--- a/phew/cli/main.py
+++ b/phew/cli/main.py
@@ -485,8 +485,18 @@ def lint(path, rule):
       compile        mx-op function missing @mx.compile
     """
     from phew.lint import lint_path
+    from phew.metal.checker import lint_metal_file
 
-    issues = lint_path(path)
+    p = Path(path)
+    if p.suffix == ".metal":
+        issues = lint_metal_file(p)
+    elif p.is_dir():
+        issues = lint_path(p)
+        for metal_file in sorted(p.rglob("*.metal")):
+            issues.extend(lint_metal_file(metal_file))
+    else:
+        issues = lint_path(p)
+
     if rule:
         issues = [i for i in issues if i.rule in rule]
 
@@ -501,6 +511,10 @@ def lint(path, rule):
         "normed_matmul": "yellow",
         "sdpa": "magenta",
         "compile": "blue",
+        "max_threads": "red",
+        "half_accumulator": "yellow",
+        "missing_simd_reduce": "magenta",
+        "unvectorized_loop": "cyan",
     }
 
     current_file = None
@@ -519,3 +533,77 @@ def lint(path, rule):
         rule_counts[i.rule] = rule_counts.get(i.rule, 0) + 1
     summary = "  ".join(f"{r}: {c}" for r, c in sorted(rule_counts.items()))
     console.print(f"\n[bold]{total} issue{'s' if total != 1 else ''}[/bold]  ({summary})")
+
+
+# ---------------------------------------------------------------------------
+# phew metal
+# ---------------------------------------------------------------------------
+
+
+@cli.group()
+def metal():
+    """Analyse and wrap .metal kernel files."""
+
+
+@metal.command("list")
+@click.argument("metal_file", type=click.Path(exists=True))
+def metal_list(metal_file):
+    """List all [[kernel]] functions found in METAL_FILE."""
+    from phew.metal.parser import parse_kernels
+
+    source = Path(metal_file).read_text(errors="replace")
+    kernels = parse_kernels(source)
+
+    if not kernels:
+        console.print("[yellow]No [[kernel]] functions found.[/yellow]")
+        return
+
+    table = Table(title=f"Kernels in {Path(metal_file).name}", box=box.ROUNDED)
+    table.add_column("Line", style="dim", justify="right")
+    table.add_column("Name", style="cyan")
+    table.add_column("Inputs", justify="right")
+    table.add_column("Outputs", justify="right")
+    table.add_column("Constants", justify="right")
+    table.add_column("max_threads", justify="center")
+
+    for sig in kernels:
+        table.add_row(
+            str(sig.line),
+            sig.name,
+            str(len(sig.input_args)),
+            str(len(sig.output_args)),
+            str(len(sig.constant_args)),
+            "[green]yes[/green]" if sig.has_max_threads_attr else "[red]no[/red]",
+        )
+
+    console.print(table)
+
+
+@metal.command("wrap")
+@click.argument("metal_file", type=click.Path(exists=True))
+@click.option("--output", "-o", default=None, help="Output .py file (default: stdout)")
+@click.option(
+    "--kernel",
+    "-k",
+    multiple=True,
+    help="Only wrap specific kernel(s) by name (default: all)",
+)
+def metal_wrap(metal_file, output, kernel):
+    """Generate mx.fast.metal_kernel Python wrappers for kernels in METAL_FILE."""
+    from phew.metal.parser import parse_kernels
+    from phew.metal.wrapper import generate_file
+
+    source = Path(metal_file).read_text(errors="replace")
+    kernels = parse_kernels(source)
+
+    if not kernels:
+        raise click.ClickException("No [[kernel]] functions found.")
+
+    include = list(kernel) if kernel else None
+    text = generate_file(kernels, metal_file, include=include)
+
+    if output:
+        Path(output).write_text(text)
+        console.print(f"[green]Wrapper written to {output}[/green]")
+    else:
+        console.print(text)

--- a/phew/metal/__init__.py
+++ b/phew/metal/__init__.py
@@ -1,0 +1,6 @@
+"""phew.metal — static analysis and wrapping for .metal kernel files."""
+
+from .checker import lint_metal_file
+from .parser import KernelArg, KernelSig, parse_kernels
+
+__all__ = ["KernelArg", "KernelSig", "parse_kernels", "lint_metal_file"]

--- a/phew/metal/checker.py
+++ b/phew/metal/checker.py
@@ -1,0 +1,35 @@
+"""Lint a .metal file: parse kernels, run all Metal rules, return LintIssue list."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from phew.lint.rule import LintIssue
+
+from .lint_rules import ALL_METAL_RULES, MetalLintIssue, MetalRule
+from .parser import parse_kernels
+
+
+def _to_lint_issue(m: MetalLintIssue) -> LintIssue:
+    return LintIssue(file=m.file, line=m.line, rule=m.rule, message=m.message)
+
+
+def lint_metal_file(
+    path: str | Path,
+    rules: list[MetalRule] | None = None,
+) -> list[LintIssue]:
+    """Parse and lint a single .metal file, returning standard LintIssue objects."""
+    path = Path(path)
+    source = path.read_text(errors="replace")
+    kernels = parse_kernels(source)
+
+    active_rules = rules if rules is not None else ALL_METAL_RULES
+    issues: list[LintIssue] = []
+
+    for sig in kernels:
+        for rule in active_rules:
+            for m in rule.check(sig, str(path)):
+                issues.append(_to_lint_issue(m))
+
+    issues.sort(key=lambda i: i.line)
+    return issues

--- a/phew/metal/lint_rules.py
+++ b/phew/metal/lint_rules.py
@@ -1,0 +1,219 @@
+"""Metal-specific lint rules operating on parsed KernelSig objects."""
+
+from __future__ import annotations
+
+import re
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+from .parser import KernelSig
+
+
+@dataclass
+class MetalLintIssue:
+    file: str
+    line: int
+    kernel: str
+    rule: str
+    message: str
+
+
+class MetalRule(ABC):
+    id: str
+    description: str
+
+    @abstractmethod
+    def check(self, sig: KernelSig, filename: str) -> list[MetalLintIssue]: ...
+
+
+# ---------------------------------------------------------------------------
+# Rule: missing [[max_total_threads_per_threadgroup]]
+# ---------------------------------------------------------------------------
+
+
+class MaxThreadsRule(MetalRule):
+    id = "max_threads"
+    description = (
+        "kernel missing [[max_total_threads_per_threadgroup(N)]]"
+        "  →  hint lets the compiler optimize register allocation"
+    )
+
+    def check(self, sig: KernelSig, filename: str) -> list[MetalLintIssue]:
+        if sig.has_max_threads_attr:
+            return []
+        return [
+            MetalLintIssue(
+                file=filename,
+                line=sig.line,
+                kernel=sig.name,
+                rule=self.id,
+                message=(
+                    f"kernel {sig.name}() has no [[max_total_threads_per_threadgroup(N)]]"
+                    "  →  add to let the compiler optimise register allocation"
+                ),
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Rule: half-typed accumulator variable
+# ---------------------------------------------------------------------------
+
+# Matches `half varname` or `half varname =` but not `device const half *` etc.
+_RE_HALF_ACC = re.compile(
+    r"(?<![*&])\bhalf\s+(\w+)\s*(?:=|;|\[)",
+)
+# Exclude pointer/reference declarations (those are fine — it's the scalar accumulators)
+_RE_PTR_OR_REF = re.compile(r"\b(device|constant|threadgroup)\b.*\bhalf\b")
+
+
+class HalfAccumulatorRule(MetalRule):
+    id = "half_accumulator"
+    description = (
+        "scalar `half` local variable used as accumulator"
+        "  →  use `float` to avoid precision loss and slow fp16 ALU"
+    )
+
+    def check(self, sig: KernelSig, filename: str) -> list[MetalLintIssue]:
+        issues: list[MetalLintIssue] = []
+        body_lines = sig.body.splitlines()
+        body_start_line = sig.line  # body lines are offset from kernel declaration
+
+        for offset, line in enumerate(body_lines):
+            stripped = line.strip()
+            # Skip commented lines
+            if stripped.startswith("//") or stripped.startswith("*"):
+                continue
+            # Skip address-space declarations (those are params or already-typed vars)
+            if _RE_PTR_OR_REF.search(line):
+                continue
+            for m in _RE_HALF_ACC.finditer(line):
+                varname = m.group(1)
+                issues.append(
+                    MetalLintIssue(
+                        file=filename,
+                        line=body_start_line + offset,
+                        kernel=sig.name,
+                        rule=self.id,
+                        message=(
+                            f"scalar `half {varname}` in {sig.name}()"
+                            "  →  use `float` for accumulation; convert to half only on store"
+                        ),
+                    )
+                )
+        return issues
+
+
+# ---------------------------------------------------------------------------
+# Rule: threadgroup barrier reduction without simd_sum first pass
+# ---------------------------------------------------------------------------
+
+_RE_BARRIER_REDUCTION = re.compile(
+    r"for\s*\([^)]*\)\s*\{[^}]*threadgroup_barrier\s*\([^)]*\)[^}]*\}",
+    re.DOTALL,
+)
+_RE_SIMD_SUM = re.compile(r"\bsimd_sum\s*\(")
+
+
+class MissingSimdReduceRule(MetalRule):
+    id = "missing_simd_reduce"
+    description = (
+        "threadgroup barrier reduction without prior simd_sum"
+        "  →  add simd_sum() first pass to cut barrier count by 5×"
+    )
+
+    def check(self, sig: KernelSig, filename: str) -> list[MetalLintIssue]:
+        body = sig.body
+
+        # Look for the classic pattern:
+        #   sh[tid] = acc;
+        #   threadgroup_barrier(...)
+        #   for (s = tg/2; s > 0; ...) { if (tid < s) sh[tid] += ...; threadgroup_barrier }
+        # where simd_sum() is NOT called before writing to sh[tid]
+
+        has_tg_barrier_reduction = bool(
+            re.search(
+                r"threadgroup_barrier\s*\(\s*mem_flags::mem_threadgroup\s*\)",
+                body,
+            )
+        )
+        if not has_tg_barrier_reduction:
+            return []
+
+        # If simd_sum is already present, the kernel is already doing it right
+        if _RE_SIMD_SUM.search(body):
+            return []
+
+        # Check for the store-then-reduce pattern: sh[tid] = X followed by barrier loop
+        has_sh_store = bool(re.search(r"\bsh\s*\[\s*\w+\s*\]\s*=", body))
+        if not has_sh_store:
+            return []
+
+        return [
+            MetalLintIssue(
+                file=filename,
+                line=sig.line,
+                kernel=sig.name,
+                rule=self.id,
+                message=(
+                    f"{sig.name}(): threadgroup reduction with no simd_sum() first pass"
+                    "  →  acc = simd_sum(acc); then only 1 barrier needed across SIMD groups"
+                    "  (see gemv_f16 pattern in same file)"
+                ),
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Rule: strided scalar loop over half* — vectorize to half4
+# ---------------------------------------------------------------------------
+
+_RE_STRIDED_HALF_LOOP = re.compile(
+    # for (uint i = tid; i < N; i += tg)
+    r"for\s*\(\s*\w+\s+(\w+)\s*=\s*\w+\s*;\s*\w+\s*<\s*\w+\s*;\s*\w+\s*\+=\s*\w+\s*\)"
+    r".*?"  # loop body preamble
+    r"(?:float\s*\(\s*\w+\s*\[\s*\1\s*\]\s*\)|half\s*\(\s*\w+\s*\[\s*\1\s*\]\s*\))",
+    re.DOTALL,
+)
+
+
+class VectorizationRule(MetalRule):
+    id = "unvectorized_loop"
+    description = (
+        "strided loop over half* reads one element at a time"
+        "  →  use half4/float4 loads to quadruple memory throughput"
+    )
+
+    def check(self, sig: KernelSig, filename: str) -> list[MetalLintIssue]:
+        # Check if any input is a half pointer
+        has_half_input = any("half" in a.type and a.address_space == "device" for a in sig.args)
+        if not has_half_input:
+            return []
+
+        if not _RE_STRIDED_HALF_LOOP.search(sig.body):
+            return []
+
+        return [
+            MetalLintIssue(
+                file=filename,
+                line=sig.line,
+                kernel=sig.name,
+                rule=self.id,
+                message=(
+                    f"{sig.name}(): strided loop reads half* scalarly"
+                    "  →  load as half4 (4× bandwidth); ensure dim divisible by 4 or add tail"
+                ),
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+ALL_METAL_RULES: list[MetalRule] = [
+    MaxThreadsRule(),
+    HalfAccumulatorRule(),
+    MissingSimdReduceRule(),
+    VectorizationRule(),
+]

--- a/phew/metal/parser.py
+++ b/phew/metal/parser.py
@@ -1,0 +1,267 @@
+"""Parse [[kernel]] function signatures and bodies from MSL source."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class KernelArg:
+    name: str
+    type: str  # e.g. "half", "float", "uint"
+    address_space: str  # "device", "constant", "threadgroup", "builtin"
+    is_const: bool
+    is_output: bool  # device non-const → output buffer
+    buffer_idx: int | None  # [[buffer(N)]] index, or None for builtins
+    tg_idx: int | None  # [[threadgroup(N)]] index, or None
+    raw: str  # original text of this argument
+
+
+@dataclass
+class KernelSig:
+    name: str
+    line: int  # 1-based line number of `kernel void name(`
+    args: list[KernelArg]
+    body: str  # source between the outermost { }
+    has_max_threads_attr: bool  # [[max_total_threads_per_threadgroup(...)]]
+
+    @property
+    def input_args(self) -> list[KernelArg]:
+        return [a for a in self.args if a.address_space == "device" and not a.is_output]
+
+    @property
+    def output_args(self) -> list[KernelArg]:
+        return [a for a in self.args if a.is_output]
+
+    @property
+    def constant_args(self) -> list[KernelArg]:
+        return [a for a in self.args if a.address_space == "constant"]
+
+    @property
+    def builtin_args(self) -> list[KernelArg]:
+        return [a for a in self.args if a.address_space == "builtin"]
+
+    @property
+    def threadgroup_args(self) -> list[KernelArg]:
+        return [a for a in self.args if a.address_space == "threadgroup"]
+
+
+# ---------------------------------------------------------------------------
+# Regex patterns
+# ---------------------------------------------------------------------------
+
+# Matches `[[max_total_threads_per_threadgroup(...)]]` anywhere before `kernel void`
+_RE_MAX_THREADS = re.compile(r"\[\[max_total_threads_per_threadgroup\s*\(\s*(\d+)\s*\)\]\]")
+
+# Matches `kernel void name(` — the start of a kernel declaration
+_RE_KERNEL_START = re.compile(r"\bkernel\s+void\s+(\w+)\s*\(")
+
+# Matches a single kernel argument (split on commas after balancing parens/brackets)
+_RE_BUFFER_ATTR = re.compile(r"\[\[buffer\s*\(\s*(\d+)\s*\)\]\]")
+_RE_TG_ATTR = re.compile(r"\[\[threadgroup\s*\(\s*(\d+)\s*\)\]\]")
+
+# Built-in thread-position argument names
+_BUILTINS = {
+    "thread_position_in_grid",
+    "thread_position_in_threadgroup",
+    "threadgroup_position_in_grid",
+    "threads_per_threadgroup",
+    "threads_per_grid",
+    "thread_index_in_simdgroup",
+    "simdgroup_index_in_threadgroup",
+    "thread_index_in_quadgroup",
+    "quadgroup_index_in_threadgroup",
+    "simd_lane_id",
+    "simd_group_id",
+}
+
+# address-space keywords
+_ADDR_SPACES = ("device", "constant", "threadgroup", "thread")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_body(source: str, open_brace_pos: int) -> tuple[str, int]:
+    """Return (body_text, end_pos) where body_text is between { } at open_brace_pos."""
+    depth = 0
+    i = open_brace_pos
+    start = None
+    while i < len(source):
+        ch = source[i]
+        if ch == "{":
+            depth += 1
+            if start is None:
+                start = i
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start + 1 : i], i
+        i += 1
+    return "", len(source)
+
+
+def _split_args(args_str: str) -> list[str]:
+    """Split a comma-separated argument list respecting < > and () nesting."""
+    args: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for ch in args_str:
+        if ch in "(<[":
+            depth += 1
+            current.append(ch)
+        elif ch in ")>]":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            args.append("".join(current).strip())
+            current = []
+        else:
+            current.append(ch)
+    if current:
+        args.append("".join(current).strip())
+    return [a for a in args if a]
+
+
+def _parse_arg(raw: str) -> KernelArg:
+    """Parse a single kernel argument declaration."""
+    # Check for [[buffer(N)]]
+    buf_m = _RE_BUFFER_ATTR.search(raw)
+    tg_m = _RE_TG_ATTR.search(raw)
+    buffer_idx = int(buf_m.group(1)) if buf_m else None
+    tg_idx = int(tg_m.group(1)) if tg_m else None
+
+    # Strip attributes [[...]] for type parsing
+    clean = re.sub(r"\[\[.*?\]\]", "", raw).strip()
+
+    # Detect address space
+    address_space = "builtin"
+    for space in _ADDR_SPACES:
+        if re.search(rf"\b{space}\b", clean):
+            address_space = space
+            break
+
+    is_const = bool(re.search(r"\bconst\b", clean))
+
+    # Extract name (last identifier before any [[...]])
+    tokens = re.findall(r"\b\w+\b", clean)
+    name = tokens[-1] if tokens else "unknown"
+
+    # Detect builtin by attribute
+    builtin_attrs = {
+        "thread_position_in_grid",
+        "thread_position_in_threadgroup",
+        "threadgroup_position_in_grid",
+        "threads_per_threadgroup",
+        "threads_per_grid",
+        "thread_index_in_simdgroup",
+        "simdgroup_index_in_threadgroup",
+        "thread_index_in_quadgroup",
+        "quadgroup_index_in_threadgroup",
+        "simd_lane_id",
+        "simd_group_id",
+    }
+    builtin_attr_pattern = r"\[\[(" + "|".join(re.escape(b) for b in builtin_attrs) + r")\]\]"
+    if re.search(builtin_attr_pattern, raw):
+        address_space = "builtin"
+
+    # Determine type string (everything before the name)
+    type_str = clean
+    for space in _ADDR_SPACES:
+        type_str = re.sub(rf"\b{space}\b", "", type_str)
+    type_str = re.sub(r"\bconst\b", "", type_str)
+    type_str = type_str.replace("*", "").replace("&", "").strip()
+    # Remove trailing name
+    type_str = re.sub(rf"\b{re.escape(name)}\b$", "", type_str).strip()
+
+    is_output = address_space == "device" and not is_const and buffer_idx is not None
+
+    return KernelArg(
+        name=name,
+        type=type_str,
+        address_space=address_space,
+        is_const=is_const,
+        is_output=is_output,
+        buffer_idx=buffer_idx,
+        tg_idx=tg_idx,
+        raw=raw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def parse_kernels(source: str) -> list[KernelSig]:
+    """Extract all [[kernel]] function signatures and bodies from MSL source."""
+    lines = source.splitlines(keepends=True)
+    # Build a line-start offset table for line-number lookup
+    offsets: list[int] = []
+    pos = 0
+    for line in lines:
+        offsets.append(pos)
+        pos += len(line)
+
+    def offset_to_line(offset: int) -> int:
+        lo, hi = 0, len(offsets) - 1
+        while lo < hi:
+            mid = (lo + hi + 1) // 2
+            if offsets[mid] <= offset:
+                lo = mid
+            else:
+                hi = mid - 1
+        return lo + 1  # 1-based
+
+    kernels: list[KernelSig] = []
+
+    for m in _RE_KERNEL_START.finditer(source):
+        name = m.group(1)
+        line_no = offset_to_line(m.start())
+
+        # Check for [[max_total_threads_per_threadgroup]] in the 3 lines before
+        line_idx = line_no - 1  # 0-based
+        preceding = "".join(lines[max(0, line_idx - 3) : line_idx])
+        has_max = bool(_RE_MAX_THREADS.search(preceding))
+
+        # Find the closing ) of the argument list
+        paren_start = source.index("(", m.start())
+        depth = 0
+        i = paren_start
+        while i < len(source):
+            if source[i] == "(":
+                depth += 1
+            elif source[i] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            i += 1
+        args_str = source[paren_start + 1 : i]
+        raw_args = _split_args(args_str)
+
+        # Find the opening { of the body
+        brace_pos = source.find("{", i)
+        if brace_pos == -1:
+            continue
+        body, _ = _find_body(source, brace_pos)
+
+        args = [_parse_arg(a) for a in raw_args if a.strip()]
+
+        kernels.append(
+            KernelSig(
+                name=name,
+                line=line_no,
+                args=args,
+                body=body,
+                has_max_threads_attr=has_max,
+            )
+        )
+
+    return kernels

--- a/phew/metal/wrapper.py
+++ b/phew/metal/wrapper.py
@@ -1,0 +1,146 @@
+"""Generate mx.fast.metal_kernel Python wrappers from parsed kernel signatures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .parser import KernelSig
+
+
+def _msl_type_to_mx(msl_type: str) -> str:
+    """Map MSL element type to mlx dtype string."""
+    t = msl_type.strip().lower()
+    if "half" in t:
+        return "mx.float16"
+    if "float" in t:
+        return "mx.float32"
+    if "uint" in t or "unsigned int" in t:
+        return "mx.uint32"
+    if "int" in t:
+        return "mx.int32"
+    return "mx.float32"
+
+
+def generate_wrapper(sig: KernelSig, source_path: str | Path) -> str:
+    """
+    Generate a Python snippet that wraps *sig* with mx.fast.metal_kernel.
+
+    Limitations documented inline:
+    - `constant T &scalar` args cannot be passed directly; they are flagged as TODOs.
+    - Threadgroup memory size must be set manually.
+    - Grid/threadgroup dimensions are left as TODOs.
+    """
+    source_path = Path(source_path)
+    lines: list[str] = []
+
+    inputs = sig.input_args
+    outputs = sig.output_args
+    constants = sig.constant_args
+    tg_args = sig.threadgroup_args
+
+    input_names = [a.name for a in inputs]
+    output_names = [a.name for a in outputs]
+
+    has_constants = bool(constants)
+    has_tg = bool(tg_args)
+
+    # ------------------------------------------------------------------
+    # Header comment
+    # ------------------------------------------------------------------
+    lines.append(f"# Wrapper for kernel: {sig.name}  (line {sig.line} of {source_path.name})")
+    if has_constants:
+        const_names = ", ".join(f"{a.name}: {a.type}" for a in constants)
+        lines.append(f"# NOTE: constant args ({const_names}) cannot be passed directly to")
+        lines.append("# mx.fast.metal_kernel. Options: (a) pack into a struct buffer, or")
+        lines.append("# (b) bake as template constants if known at compile time.")
+    if has_tg:
+        tg_names = ", ".join(a.name for a in tg_args)
+        lines.append(f"# NOTE: threadgroup memory ({tg_names}) size must be set via")
+        lines.append("# the threadgroup_memory_length argument in the kernel call.")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Kernel object
+    # ------------------------------------------------------------------
+    lines.append(f"_{sig.name}_kernel = mx.fast.metal_kernel(")
+    lines.append(f'    name="{sig.name}",')
+    lines.append(f"    input_names={input_names!r},")
+    lines.append(f"    output_names={output_names!r},")
+    lines.append(f'    source=open("{source_path.name}").read(),')
+    lines.append("    # header is not needed — kernel is declared in the source above")
+    lines.append(")")
+    lines.append("")
+
+    # ------------------------------------------------------------------
+    # Python wrapper function
+    # ------------------------------------------------------------------
+    py_args = [f"{a.name}: mx.array" for a in inputs]
+    if has_constants:
+        for a in constants:
+            py_type = "int" if "uint" in a.type or "int" in a.type else "float"
+            py_args.append(f"{a.name}: {py_type}")
+    py_args.append("# TODO: grid, threadgroup")
+
+    lines.append(f"def {sig.name}(")
+    for arg in py_args:
+        lines.append(f"    {arg},")
+    lines.append(") -> list[mx.array]:")
+
+    # Docstring
+    lines.append(f'    """Call the {sig.name} Metal kernel via mx.fast.metal_kernel.')
+    lines.append("")
+    if has_constants:
+        lines.append("    Constant args must be converted to mx.array inputs or template")
+        lines.append("    parameters before calling. See comment above.")
+    lines.append('    """')
+
+    lines.append(f"    return _{sig.name}_kernel(")
+    lines.append(f"        inputs=[{', '.join(a.name for a in inputs)}],")
+
+    # Output shapes — best-effort guess from first input
+    if outputs and inputs:
+        out_shapes = ", ".join(f"{inputs[0].name}.shape" for _ in outputs)
+        out_dtypes = ", ".join(_msl_type_to_mx(o.type) for o in outputs)
+        lines.append(f"        output_shapes=[{out_shapes}],  # TODO: verify")
+        lines.append(f"        output_dtypes=[{out_dtypes}],  # TODO: verify")
+    else:
+        lines.append("        output_shapes=[],  # TODO")
+        lines.append("        output_dtypes=[],  # TODO")
+
+    lines.append("        grid=(1, 1, 1),  # TODO: set dispatch grid")
+    lines.append("        threadgroup=(256, 1, 1),  # TODO: tune")
+    if has_tg:
+        lines.append(
+            "        threadgroup_memory_length=[0],  # TODO: set threadgroup mem size in bytes"
+        )
+    lines.append("    )")
+
+    return "\n".join(lines)
+
+
+def generate_file(
+    kernels: list[KernelSig],
+    source_path: str | Path,
+    include: list[str] | None = None,
+) -> str:
+    """Generate a complete Python file wrapping all (or selected) kernels."""
+    source_path = Path(source_path)
+    parts: list[str] = [
+        "# Generated by phew metal wrap",
+        f"# Source: {source_path.name}",
+        "#",
+        "# Review all TODO comments before use.",
+        "",
+        "import mlx.core as mx",
+        "",
+        "",
+    ]
+
+    for sig in kernels:
+        if include and sig.name not in include:
+            continue
+        parts.append(generate_wrapper(sig, source_path))
+        parts.append("")
+        parts.append("")
+
+    return "\n".join(parts)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "phew-mlx"
-version = "0.2.5"
+version = "0.2.6"
 description = "Probably Hardly Ever Works — search-based superoptimizer for MLX/Metal"
 requires-python = ">=3.10"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -650,7 +650,7 @@ wheels = [
 
 [[package]]
 name = "phew-mlx"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- Adds `phew/metal/` module: regex-based MSL kernel parser, 4 lint rules, `mx.fast.metal_kernel` wrapper generator
- Extends `phew lint` to handle `.metal` files automatically
- Adds `phew metal list` and `phew metal wrap` CLI subcommands
- Updates README and SKILL.md

## Metal lint rules

| Rule | What it catches |
|---|---|
| `max_threads` | kernel missing `[[max_total_threads_per_threadgroup(N)]]` |
| `missing_simd_reduce` | threadgroup barrier reduction without `simd_sum` first pass |
| `half_accumulator` | scalar `half` local used as accumulator |
| `unvectorized_loop` | strided loop over `half*` reading scalarly instead of `half4` |

## Known limitations

- `constant T &scalar` args cannot be passed directly to `mx.fast.metal_kernel` — wrapper generator flags these as TODOs
- No full C++ parse: regex-based, handles well-structured kernel declarations
- Texture and struct arguments out of scope for now