### PR TITLE
feat: QoL round 2 — tighter lint, colored help, update check, smarter compile rule

### DIFF
--- a/phew/cli/main.py
+++ b/phew/cli/main.py
@@ -19,13 +19,65 @@ import sys
 from pathlib import Path
 from typing import Callable
 
-import click
+import rich_click as click
 from rich import box
 from rich.console import Console
 from rich.markup import escape
 from rich.table import Table
 
 console = Console()
+
+
+# ---------------------------------------------------------------------------
+# Version check
+# ---------------------------------------------------------------------------
+
+
+def _check_for_updates() -> None:
+    """Warn if a newer version is available on PyPI. Result cached for 24 h."""
+    import importlib.metadata
+    import json
+    import urllib.request
+    from datetime import datetime, timedelta
+    from pathlib import Path
+
+    try:
+        current = importlib.metadata.version("phew-mlx")
+    except importlib.metadata.PackageNotFoundError:
+        return
+
+    cache_dir = Path.home() / ".cache" / "phew"
+    cache_file = cache_dir / "version_check.json"
+
+    latest: str | None = None
+    if cache_file.exists():
+        try:
+            data = json.loads(cache_file.read_text())
+            if datetime.now() - datetime.fromisoformat(data["checked_at"]) < timedelta(hours=24):
+                latest = data.get("latest")
+        except Exception:
+            pass
+
+    if latest is None:
+        try:
+            with urllib.request.urlopen("https://pypi.org/pypi/phew-mlx/json", timeout=1) as resp:
+                latest = json.loads(resp.read())["info"]["version"]
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            cache_file.write_text(
+                json.dumps({"checked_at": datetime.now().isoformat(), "latest": latest})
+            )
+        except Exception:
+            return
+
+    if latest and latest != current:
+        try:
+            if tuple(int(x) for x in latest.split(".")) > tuple(int(x) for x in current.split(".")):
+                console.print(
+                    f"[yellow]phew {latest} is available (you have {current}) — "
+                    "run [bold]phew upgrade[/bold] to update.[/yellow]"
+                )
+        except Exception:
+            pass
 
 
 # ---------------------------------------------------------------------------
@@ -102,6 +154,7 @@ def _get_fn_and_factory(mod) -> tuple[Callable, Callable]:
 @click.version_option(package_name="phew-mlx")
 def cli():
     """PHEW — MLX/Metal optimizer for Apple Silicon."""
+    _check_for_updates()
 
 
 # ---------------------------------------------------------------------------
@@ -682,10 +735,12 @@ def lint(path, rule, as_json):
         "unvectorized_loop": "cyan",
     }
 
+    rule_width = max(len(i.rule) for i in issues)
+
     for issue in issues:
         color = rule_colors.get(issue.rule, "white")
         loc = f"{issue.file}:{issue.line}"
-        rule_col = f"[{color}]{issue.rule:<20}[/{color}]"
+        rule_col = f"[{color}]{issue.rule:<{rule_width}}[/{color}]"
         # Split on  →  to color the suggestion green
         parts = issue.message.split("  →  ", 1)
         if len(parts) == 2:

--- a/phew/lint/_utils.py
+++ b/phew/lint/_utils.py
@@ -68,6 +68,62 @@ def contains(node: ast.expr, predicate, depth: int = 0, max_depth: int = 8) -> b
     )
 
 
+# Type annotation fragments that indicate non-compilable MLX arguments.
+_NON_COMPILABLE_FRAGMENTS: frozenset[str] = frozenset(
+    [
+        "Callable",
+        "callable",
+        "Module",  # nn.Module, PreTrainedModel, …
+        "Generator",
+        "Iterator",
+        "Iterable",
+        "AsyncGenerator",
+        "Tokenizer",
+        "Processor",
+    ]
+)
+
+# Arg names that almost always indicate non-compilable objects when unannotated.
+_NON_COMPILABLE_ARG_NAMES: frozenset[str] = frozenset(
+    ["model", "tokenizer", "sampler", "processor", "logits_processor", "logits_processors"]
+)
+
+
+def has_noncompilable_args(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
+    """Return True if any parameter is likely non-compilable by ``mx.compile``."""
+    all_args = node.args.args + node.args.posonlyargs + node.args.kwonlyargs
+    for arg in all_args:
+        if arg.annotation is not None:
+            try:
+                ann = ast.unparse(arg.annotation)
+            except Exception:
+                ann = ""
+            if any(frag in ann for frag in _NON_COMPILABLE_FRAGMENTS):
+                return True
+        if arg.arg in _NON_COMPILABLE_ARG_NAMES:
+            return True
+    return False
+
+
+def uses_mx_random(node: ast.AST) -> bool:
+    """True if *node* calls ``mx.random.*`` or accesses ``mx.random``."""
+    for n in ast.walk(node):
+        if not isinstance(n, ast.Attribute):
+            continue
+        # mx.random  (attr access — random.categorical etc. chained on this)
+        if n.attr == "random" and isinstance(n.value, ast.Name) and n.value.id in ("mx", "mlx"):
+            return True
+        # mx.random.X  (e.g. mx.random.categorical)
+        if (
+            isinstance(n.value, ast.Attribute)
+            and n.value.attr == "random"
+            and isinstance(n.value.value, ast.Name)
+            and n.value.value.id in ("mx", "mlx")
+        ):
+            return True
+    return False
+
+
 def has_compile_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
     for dec in node.decorator_list:
         if isinstance(dec, ast.Attribute) and dec.attr == "compile":

--- a/phew/lint/compile.py
+++ b/phew/lint/compile.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 
-from ._utils import has_compile_decorator, node_uses_mx
+from ._utils import has_compile_decorator, has_noncompilable_args, node_uses_mx, uses_mx_random
 from .rule import LintIssue, Rule
 
 
@@ -33,15 +33,28 @@ class _Visitor(ast.NodeVisitor):
         args = node.args.args
         if args and args[0].arg in ("self", "cls"):
             return
-        if node_uses_mx(node):
-            self.issues.append(
-                LintIssue(
-                    file=self.filename,
-                    line=node.lineno,
-                    rule=CompileRule.id,
-                    message=f"def {node.name}()  →  add @mx.compile",
-                )
+        _random = uses_mx_random(node)
+        if not node_uses_mx(node) and not _random:
+            return
+        # Skip functions whose arguments can't be traced by mx.compile
+        # (nn.Module, Callable, Tokenizer, Generator, etc.).
+        if has_noncompilable_args(node):
+            return
+        if _random:
+            msg = (
+                f"def {node.name}()  →  "
+                "@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)"
             )
+        else:
+            msg = f"def {node.name}()  →  add @mx.compile"
+        self.issues.append(
+            LintIssue(
+                file=self.filename,
+                line=node.lineno,
+                rule=CompileRule.id,
+                message=msg,
+            )
+        )
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._check(node)

--- a/phew/lint/compile.py
+++ b/phew/lint/compile.py
@@ -39,10 +39,7 @@ class _Visitor(ast.NodeVisitor):
                     file=self.filename,
                     line=node.lineno,
                     rule=CompileRule.id,
-                    message=(
-                        f"def {node.name}() uses mx ops but has no @mx.compile"
-                        "  →  add @mx.compile for ~1.5–3× free speedup"
-                    ),
+                    message=f"def {node.name}()  →  add @mx.compile",
                 )
             )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "mlx>=0.24.0",
     "numpy>=1.26.0",
     "click>=8.1.0,<9",
+    "rich-click>=1.6.0",
     "scipy>=1.12.0",      # ILP extraction via scipy.optimize.milp
     "egglog>=0.9.0",      # e-graph saturation
     "rich>=13.0.0",       # CLI output

--- a/tests/test_lint_compile.py
+++ b/tests/test_lint_compile.py
@@ -1,0 +1,142 @@
+"""Tests for the compile lint rule — compile-ability analysis."""
+
+from __future__ import annotations
+
+import ast
+
+from phew.lint.compile import CompileRule
+
+rule = CompileRule()
+
+
+def _issues(src: str):
+    tree = ast.parse(src)
+    return rule.check(tree, "<test>")
+
+
+# ---------------------------------------------------------------------------
+# Basic detection
+# ---------------------------------------------------------------------------
+
+
+def test_simple_mx_function_flagged():
+    src = """
+def forward(x):
+    return mx.softmax(x)
+"""
+    assert len(_issues(src)) == 1
+    assert "forward" in _issues(src)[0].message
+    assert "@mx.compile" in _issues(src)[0].message
+
+
+def test_already_decorated_skipped():
+    src = """
+@mx.compile
+def forward(x):
+    return mx.softmax(x)
+"""
+    assert _issues(src) == []
+
+
+def test_private_function_skipped():
+    src = """
+def _forward(x):
+    return mx.softmax(x)
+"""
+    assert _issues(src) == []
+
+
+def test_class_method_skipped():
+    src = """
+class Model:
+    def forward(self, x):
+        return mx.softmax(x)
+"""
+    assert _issues(src) == []
+
+
+def test_no_mx_ops_skipped():
+    src = """
+def add(x, y):
+    return x + y
+"""
+    assert _issues(src) == []
+
+
+# ---------------------------------------------------------------------------
+# Non-compilable arg suppression
+# ---------------------------------------------------------------------------
+
+
+def test_module_annotation_suppressed():
+    src = """
+def generate_step(tokens, model: nn.Module):
+    return model(tokens)
+"""
+    assert _issues(src) == []
+
+
+def test_callable_annotation_suppressed():
+    src = """
+def run(x, sampler: Callable):
+    return mx.softmax(sampler(x))
+"""
+    assert _issues(src) == []
+
+
+def test_tokenizer_annotation_suppressed():
+    src = """
+def tokenize(text, tokenizer: Tokenizer):
+    return mx.array(tokenizer.encode(text))
+"""
+    assert _issues(src) == []
+
+
+def test_model_arg_name_heuristic_suppressed():
+    src = """
+def generate(tokens, model):
+    return model(mx.softmax(tokens))
+"""
+    assert _issues(src) == []
+
+
+def test_sampler_arg_name_heuristic_suppressed():
+    src = """
+def sample(logits, sampler):
+    return mx.softmax(sampler(logits))
+"""
+    assert _issues(src) == []
+
+
+def test_no_annotation_compilable_arg_flagged():
+    """A function with only array-ish args and no annotation should still be flagged."""
+    src = """
+def forward(x, weights):
+    return mx.matmul(x, weights)
+"""
+    assert len(_issues(src)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Random state suggestion
+# ---------------------------------------------------------------------------
+
+
+def test_mx_random_suggests_partial():
+    src = """
+def sample(logits):
+    return mx.random.categorical(logits)
+"""
+    issues = _issues(src)
+    assert len(issues) == 1
+    assert "mx.random.state" in issues[0].message
+    assert "partial" in issues[0].message
+
+
+def test_mx_random_with_noncompilable_arg_suppressed():
+    """Even if random is used, non-compilable arg should still suppress the warning."""
+    src = """
+def sample(logits, sampler: Callable):
+    return mx.random.categorical(sampler(logits))
+"""
+    assert _issues(src) == []


### PR DESCRIPTION
## Summary

- **Tighter lint output**: `compile` rule message shortened to `def foo()  →  add @mx.compile`; rule column now pads to actual max width in result set (not fixed 20 chars)
- **Colored help**: switched to `rich-click` so `phew --help` renders with paneled, styled output
- **Update check**: on each invocation, compares installed version against PyPI (cached 24 h); prints a warning when a newer version is available
- **Smarter compile rule**: suppresses false positives when function args include non-compilable types (`nn.Module`, `Callable`, `Tokenizer`, `Generator` annotations, or `model`/`tokenizer`/`sampler` arg name heuristics); suggests `@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)` when `mx.random.*` is used

## Test plan

- [ ] `uv run --no-config --with pytest python -m pytest tests/ -v` — 38 tests pass
- [ ] `phew --help` renders with Rich panels
- [ ] `phew lint <file>` on a file with only `compile` hits shows tight column width
- [ ] `phew lint` on a file with `generate_step(model: nn.Module, ...)` produces no false positive
- [ ] `phew lint` on a function using `mx.random.*` suggests the `partial` decorator form