### PR TITLE
fix: all bugs from issue #11

### DIFF
--- a/phew/emit/codegen.py
+++ b/phew/emit/codegen.py
@@ -40,11 +40,15 @@ class MLXCodegen:
         # emitted function's positional parameters match how the caller passes args.
         inputs = graph.inputs()
         args = ", ".join(n.name or f"x{i}" for i, n in enumerate(inputs))
+        # Accept extra positional/keyword args so the emitted function can be
+        # called with the original input_factory args even when some non-array
+        # arguments (e.g. Python int scalars) were baked in as constants.
+        extra = (", " if args else "") + "*_, **__"
 
         if has_compile:
             lines.append("@mx.compile")
 
-        lines.append(f"def {fn_name}({args}):")
+        lines.append(f"def {fn_name}({args}{extra}):")
 
         body = self._emit_body(graph)
         for line in body:
@@ -125,6 +129,10 @@ class MLXCodegen:
                     # softmax takes axis as a scalar, not a list
                     ax = axes[0] if axes and len(axes) == 1 else axes
                     lines.append(f"{vname} = mx.softmax({ins[0]}, axis={ax})")
+                elif node.op in ("sort", "argsort"):
+                    # sort/argsort do not accept keepdims
+                    ax = node.attrs.get("axis", -1)
+                    lines.append(f"{vname} = mx.{node.op}({ins[0]}, axis={ax!r})")
                 else:
                     lines.append(f"{vname} = mx.{node.op}({ins[0]}, axis={axes}, keepdims={kd})")
 
@@ -147,6 +155,16 @@ class MLXCodegen:
                     lines.append(f"{vname} = {ins[0]} - {ins[1]}")
                 elif op == "div" and len(ins) == 2:
                     lines.append(f"{vname} = {ins[0]} / {ins[1]}")
+                elif op == "argpartition":
+                    kth = node.attrs.get("kth", 0)
+                    axis = node.attrs.get("axis", -1)
+                    lines.append(f"{vname} = mx.argpartition({ins[0]}, kth={kth!r}, axis={axis!r})")
+                elif op in ("sort", "argsort"):
+                    axis = node.attrs.get("axis", -1)
+                    lines.append(f"{vname} = mx.{op}({ins[0]}, axis={axis!r})")
+                elif op in ("tril", "triu"):
+                    k = node.attrs.get("k", 0)
+                    lines.append(f"{vname} = mx.{op}({ins[0]}, k={k!r})")
                 elif len(ins) == 1:
                     lines.append(f"{vname} = mx.{op}({ins[0]})")
                 else:

--- a/phew/ir/dtype.py
+++ b/phew/ir/dtype.py
@@ -11,6 +11,8 @@ class Dtype(Enum):
     int16 = "int16"
     int8 = "int8"
     uint8 = "uint8"
+    uint16 = "uint16"
+    uint32 = "uint32"
     bool_ = "bool"
 
     @property
@@ -23,6 +25,8 @@ class Dtype(Enum):
             "int16": 2,
             "int8": 1,
             "uint8": 1,
+            "uint16": 2,
+            "uint32": 4,
             "bool": 1,
         }
         return _sizes[self.value]
@@ -45,6 +49,8 @@ class Dtype(Enum):
             "int16": "int16",
             "int8": "int8",
             "uint8": "uint8",
+            "uint16": "uint16",
+            "uint32": "uint32",
             "bool": "bool_",
         }
         return _map[self.value]
@@ -61,6 +67,8 @@ class Dtype(Enum):
             mx.int16: Dtype.int16,
             mx.int8: Dtype.int8,
             mx.uint8: Dtype.uint8,
+            mx.uint16: Dtype.uint16,
+            mx.uint32: Dtype.uint32,
             mx.bool_: Dtype.bool_,
         }
         return _map[mlx_dtype]

--- a/phew/ir/importer.py
+++ b/phew/ir/importer.py
@@ -152,6 +152,10 @@ class _TracedArray:
         return self._node.shape
 
     @property
+    def ndim(self):
+        return len(self._node.shape)
+
+    @property
     def dtype(self):
         return self._node.dtype
 
@@ -842,7 +846,11 @@ class _TracingContext:
         from phew.ir.dtype import Dtype as _Dtype
 
         node = Elementwise(
-            shape=x.shape, dtype=_Dtype.int32, inputs=[x._node.id], op="argpartition"
+            shape=x.shape,
+            dtype=_Dtype.int32,
+            inputs=[x._node.id],
+            op="argpartition",
+            attrs={"kth": kth, "axis": axis},
         )
         self._graph.add(node)
         return _TracedArray(node, self._graph)
@@ -1542,8 +1550,8 @@ class _TracingContext:
     def sort(self, x, axis=-1, **_):
         if not isinstance(x, _TracedArray):
             return x
-        node = Reduce(
-            shape=x.shape, dtype=x.dtype, inputs=[x._node.id], op="sort", axes=(), keepdims=True
+        node = Elementwise(
+            shape=x.shape, dtype=x.dtype, inputs=[x._node.id], op="sort", attrs={"axis": axis}
         )
         self._graph.add(node)
         return _TracedArray(node, self._graph)
@@ -1553,13 +1561,34 @@ class _TracingContext:
             return x
         from phew.ir.dtype import Dtype as _Dtype
 
-        node = Reduce(
+        node = Elementwise(
             shape=x.shape,
             dtype=_Dtype.int32,
             inputs=[x._node.id],
             op="argsort",
-            axes=(),
-            keepdims=True,
+            attrs={"axis": axis},
+        )
+        self._graph.add(node)
+        return _TracedArray(node, self._graph)
+
+    def tril(self, x, k=0, **_):
+        if not isinstance(x, _TracedArray):
+            import mlx.core as _mx
+
+            return _mx.tril(x, k=k)
+        node = Elementwise(
+            shape=x.shape, dtype=x.dtype, inputs=[x._node.id], op="tril", attrs={"k": k}
+        )
+        self._graph.add(node)
+        return _TracedArray(node, self._graph)
+
+    def triu(self, x, k=0, **_):
+        if not isinstance(x, _TracedArray):
+            import mlx.core as _mx
+
+            return _mx.triu(x, k=k)
+        node = Elementwise(
+            shape=x.shape, dtype=x.dtype, inputs=[x._node.id], op="triu", attrs={"k": k}
         )
         self._graph.add(node)
         return _TracedArray(node, self._graph)
@@ -1755,6 +1784,8 @@ def trace_to_graph(
         "sort",
         "argsort",
         "topk",
+        "tril",
+        "triu",
         "partition",
         "cumsum",
         "cumprod",

--- a/phew/lint/_utils.py
+++ b/phew/lint/_utils.py
@@ -133,6 +133,13 @@ def has_compile_decorator(node: ast.FunctionDef | ast.AsyncFunctionDef) -> bool:
                 return True
             if is_call(dec, "compile"):
                 return True
+            # @partial(mx.compile, ...) or @partial(compile, ...)
+            if is_call(dec, "partial") and dec.args:  # type: ignore[union-attr]
+                first = dec.args[0]  # type: ignore[union-attr]
+                if isinstance(first, ast.Attribute) and first.attr == "compile":
+                    return True
+                if isinstance(first, ast.Name) and first.id == "compile":
+                    return True
     return False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "phew-mlx"
-version = "0.2.8"
+version = "0.2.9"
 description = "Probably Hardly Ever Works — search-based superoptimizer for MLX/Metal"
 requires-python = ">=3.10"
 dependencies = [

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -48,6 +48,9 @@ def test_dtype_itemsize():
     assert Dtype.float32.itemsize == 4
     assert Dtype.float16.itemsize == 2
     assert Dtype.int8.itemsize == 1
+    assert Dtype.uint8.itemsize == 1
+    assert Dtype.uint16.itemsize == 2
+    assert Dtype.uint32.itemsize == 4
 
 
 def test_memdep_flags():

--- a/tests/test_lint_compile.py
+++ b/tests/test_lint_compile.py
@@ -38,6 +38,26 @@ def forward(x):
     assert _issues(src) == []
 
 
+def test_partial_mx_compile_skipped():
+    """@partial(mx.compile, shapeless=True) must not trigger the rule."""
+    src = """
+@partial(mx.compile, shapeless=True)
+def swiglu(gate, x):
+    return nn.silu(gate) * x
+"""
+    assert _issues(src) == []
+
+
+def test_partial_compile_with_random_state_skipped():
+    """@partial(mx.compile, inputs=mx.random.state, ...) must not trigger the rule."""
+    src = """
+@partial(mx.compile, inputs=mx.random.state, outputs=mx.random.state)
+def sample(logits):
+    return mx.random.categorical(logits)
+"""
+    assert _issues(src) == []
+
+
 def test_private_function_skipped():
     src = """
 def _forward(x):


### PR DESCRIPTION
Fixes #11.

## Bug 1 — `@partial(mx.compile, ...)` false positive
`has_compile_decorator()` now recognises `partial(mx.compile, ...)` (covers `shapeless=True`, `inputs=mx.random.state`, etc.).

## Bug 2 — `KeyError: mlx.core.uint32`
Added `uint16` and `uint32` to `Dtype` enum, `itemsize`, `to_mlx`, and `from_mlx`. `mx.quantize` outputs no longer crash the graph tracer.

## Bug 3 — `_TracedArray` missing `.ndim`
Added `@property ndim` returning `len(self._node.shape)`.

## Bug 4 — `mx.tril` / `mx.triu` not in tracer
Added `tril`/`triu` methods to `_TracingContext` (store `k` in `node.attrs`), registered in monkey-patch list, codegen emits `mx.tril(x, k=k)`.

## Bug 5 — Arity mismatch with scalar args
Emitted function now has `def optimized(x0, *_, **__)` signature — absorbs extra positional/keyword args baked in as constants.

## Bug 6 — `argpartition` drops `kth`
Store `kth` and `axis` in `Elementwise.attrs` at trace time; codegen emits `mx.argpartition(x, kth=kth, axis=axis)`.

## Bug 7 — `argsort` receives unsupported `keepdims`
Converted `sort`/`argsort` tracer from `Reduce` (which stores `keepdims`) to `Elementwise` with `axis` in attrs. Codegen emits `mx.sort(x, axis=ax)` / `mx.argsort(x, axis=ax)` without `keepdims`.

## Test plan
- [ ] `pytest tests/` — 40 tests pass
- [ ] `@partial(mx.compile, shapeless=True)` produces no lint hit
- [ ] `Dtype.from_mlx(mx.uint32)` works
- [ ] `x.ndim` accessible during trace
- [ ] `mx.tril` traces without `TypeError`
- [ ] `fn(a, k=2)` — optimized function callable with original args
- [ ] Emitted `argpartition` includes `kth`
- [ ] Emitted `argsort` has no `keepdims`