### PR TITLE
fix: multi-output graph support (Bug 15) and Metal kernel shape selection (Bug 16)

### DIFF
--- a/phew/egraph/extraction.py
+++ b/phew/egraph/extraction.py
@@ -115,12 +115,31 @@ class _GraphReconstructor:
         self._cache: dict[str, "Node"] = {}
 
     def build(self, expr_str: str) -> "Graph | None":
-        """Return a reconstructed Graph for *expr_str*, or None on failure."""
+        """Return a reconstructed Graph for *expr_str* (single-output), or None."""
         try:
             root_node = self._reconstruct(expr_str)
             if root_node is None:
                 return None
             self.new_graph.outputs = [root_node.id]
+            return self.new_graph
+        except Exception:
+            return None
+
+    def build_multi(self, expr_strs: "list[str]") -> "Graph | None":
+        """Return a reconstructed Graph for all outputs, or None on failure.
+
+        Each entry in *expr_strs* corresponds to one graph output in order.
+        All outputs are reconstructed sharing the same new_graph so that
+        shared intermediate nodes are not duplicated.
+        """
+        try:
+            output_ids: list[int] = []
+            for expr_str in expr_strs:
+                root_node = self._reconstruct(expr_str)
+                if root_node is None:
+                    return None
+                output_ids.append(root_node.id)
+            self.new_graph.outputs = output_ids
             return self.new_graph
         except Exception:
             return None
@@ -244,8 +263,16 @@ class _GraphReconstructor:
         return self._fallback(expr_str)
 
     def _fallback(self, expr_str: str) -> "Node | None":
-        """Return the original graph's output node when we can't reconstruct."""
-        # Return the original output node so the graph stays valid
+        """Return a safe fallback node when we can't reconstruct *expr_str*.
+
+        Tries to find the matching original node via str_node_map first so that
+        the fallback for a particular output is that output's own original node,
+        not an unrelated one.
+        """
+        node = self.str_node_map.get(expr_str)
+        if node is not None and node.id in self.new_graph:
+            return self.new_graph[node.id]
+        # Last resort: the last output of the original graph
         if self.original.outputs:
             oid = self.original.outputs[-1]
             if oid in self.new_graph:
@@ -281,7 +308,7 @@ class Extractor:
     def extract(
         self,
         egraph: "EGraph",
-        root_expr: "Expr",
+        root_exprs: "list[Expr] | Expr",
         node_map,
         original_graph: "Graph",
         str_node_map: "dict[str, Node] | None" = None,
@@ -290,15 +317,21 @@ class Extractor:
 
         cost_model = CostModel()
 
+        # Accept either a single Expr (legacy callers) or a list.
+        if not isinstance(root_exprs, list):
+            root_exprs = [root_exprs]
+
         if self.strategy == "greedy":
             return self._greedy(
-                egraph, root_expr, node_map, original_graph, cost_model, str_node_map
+                egraph, root_exprs, node_map, original_graph, cost_model, str_node_map
             )
         else:
-            return self._ilp(egraph, root_expr, node_map, original_graph, cost_model, str_node_map)
+            return self._ilp(
+                egraph, root_exprs, node_map, original_graph, cost_model, str_node_map
+            )
 
     def _greedy(
-        self, egraph, root_expr, node_map, graph, cost_model, str_node_map=None
+        self, egraph, root_exprs, node_map, graph, cost_model, str_node_map=None
     ) -> ExtractionResult:
         """Use egglog's built-in greedy extractor with a bytes-moved cost model."""
 
@@ -313,17 +346,24 @@ class Extractor:
                 return c.bytes_moved + sum(children_costs)
             return 1.0 + sum(children_costs)
 
-        extracted, cost = egraph.extract(
-            root_expr,
-            include_cost=True,
-            cost_model=bytes_moved_cost,
-        )
+        # Extract each output independently (multi-output support).
+        # Total cost is the sum across all outputs.
+        extracted_list = []
+        total_cost = 0.0
+        for root_expr in root_exprs:
+            extracted, cost = egraph.extract(
+                root_expr,
+                include_cost=True,
+                cost_model=bytes_moved_cost,
+            )
+            extracted_list.append(extracted)
+            total_cost += float(cost)
 
-        new_graph = self._egglog_to_graph(extracted, node_map, graph, str_node_map)
-        return ExtractionResult(graph=new_graph, cost=float(cost), strategy="greedy")
+        new_graph = self._egglog_to_graph(extracted_list, node_map, graph, str_node_map)
+        return ExtractionResult(graph=new_graph, cost=total_cost, strategy="greedy")
 
     def _ilp(
-        self, egraph, root_expr, node_map, graph, cost_model, str_node_map=None
+        self, egraph, root_exprs, node_map, graph, cost_model, str_node_map=None
     ) -> ExtractionResult:
         """Joint ILP extraction via scipy.optimize.milp.
 
@@ -337,37 +377,44 @@ class Extractor:
         try:
             from scipy.optimize import milp  # noqa: F401
         except ImportError:
-            return self._greedy(egraph, root_expr, node_map, graph, cost_model, str_node_map)
+            return self._greedy(egraph, root_exprs, node_map, graph, cost_model, str_node_map)
 
-        result = self._greedy(egraph, root_expr, node_map, graph, cost_model, str_node_map)
+        result = self._greedy(egraph, root_exprs, node_map, graph, cost_model, str_node_map)
         result.strategy = "ilp-fallback-greedy"
         return result
 
     def _egglog_to_graph(
         self,
-        extracted_expr,
+        extracted_exprs: "list",
         node_map,
         original_graph: "Graph",
         str_node_map: "dict[str, Node] | None" = None,
     ) -> "Graph":
-        """Convert an extracted egglog expression back to a phew Graph.
+        """Convert extracted egglog expressions back to a phew Graph.
 
-        Parses str(extracted_expr) and reconstructs the graph bottom-up.
-        Falls back to original_graph if reconstruction fails.
+        Accepts a list of extracted expressions, one per graph output.
+        All outputs are reconstructed sharing a single new_graph so that
+        shared intermediate nodes are reused rather than duplicated.
+        Falls back to original_graph if reconstruction fails for any output.
         """
         if str_node_map is None:
             str_node_map = {}
 
+        # Fast path for single-output: if the extracted expression directly
+        # matches an original node, no rewrites were applied.
+        if len(extracted_exprs) == 1:
+            try:
+                expr_str = str(extracted_exprs[0])
+            except Exception:
+                return original_graph
+            if expr_str in str_node_map:
+                return original_graph
+
         try:
-            expr_str = str(extracted_expr)
+            expr_strs = [str(e) for e in extracted_exprs]
         except Exception:
             return original_graph
 
-        # Fast path: if the extracted expression directly matches an original
-        # node, no rewrites were applied — return original unchanged.
-        if expr_str in str_node_map:
-            return original_graph
-
         reconstructor = _GraphReconstructor(original_graph, str_node_map)
-        new_graph = reconstructor.build(expr_str)
+        new_graph = reconstructor.build_multi(expr_strs)
         return new_graph if new_graph is not None else original_graph

--- a/phew/egraph/rules_egglog.py
+++ b/phew/egraph/rules_egglog.py
@@ -126,8 +126,9 @@ def fused_ew_chain(op1: i64, op2: i64, a: Tensor) -> Tensor: ...
 def build_egraph(egraph, graph: "Graph") -> tuple:
     """Encode a phew Graph into egglog expressions.
 
-    Returns (root_expr, node_map, str_node_map) where:
-      root_expr    — egglog Expr for the output node
+    Returns (root_exprs, node_map, str_node_map) where:
+      root_exprs   — list of egglog Exprs, one per graph output (single-output
+                     graphs still return a one-element list for uniformity)
       node_map     — dict mapping id(egglog_expr) → phew Node  (for cost model)
       str_node_map — dict mapping str(egglog_expr) → phew Node  (for round-trip)
     """
@@ -220,13 +221,17 @@ def build_egraph(egraph, graph: "Graph") -> tuple:
         return expr
 
     if graph.outputs:
-        root_expr = encode(graph.outputs[-1])
+        # Encode ALL outputs so the e-graph sees the full computation.
+        # Multi-output functions (e.g. returning (y, state)) previously only
+        # encoded the last output, causing the extractor to drop all but the
+        # last return value and produce a shape-mismatched candidate.
+        root_exprs = [encode(oid) for oid in graph.outputs]
     else:
         for node in graph.topo_order():
             encode(node.id)
-        root_expr = list(expr_cache.values())[-1] if expr_cache else None
+        root_exprs = [list(expr_cache.values())[-1]] if expr_cache else []
 
-    return root_expr, node_map, str_node_map
+    return root_exprs, node_map, str_node_map
 
 
 # ---------------------------------------------------------------------------

--- a/phew/egraph/saturation.py
+++ b/phew/egraph/saturation.py
@@ -69,7 +69,7 @@ class EGraphSaturator:
         from .rules_egglog import RULE_SETS, bottleneck_rule_sets, build_egraph
 
         egraph = EGraph()
-        root_expr, node_map, str_node_map = build_egraph(egraph, graph)
+        root_exprs, node_map, str_node_map = build_egraph(egraph, graph)
 
         # Select which rule sets to register based on bottleneck
         active_sets = bottleneck_rule_sets(
@@ -92,4 +92,4 @@ class EGraphSaturator:
             classes_after=0,
             rule_stats={name: 0 for name in active_sets},
         )
-        return graph, stats, egraph, root_expr, node_map, str_node_map
+        return graph, stats, egraph, root_exprs, node_map, str_node_map

--- a/phew/emit/codegen.py
+++ b/phew/emit/codegen.py
@@ -515,13 +515,26 @@ class MLXCodegen:
                 target_numel *= s
             matching_inp = None
             if node.input_shapes:
+                # 1. Prefer exact shape match so that dynamic shape expr has
+                #    the right number of dimensions (avoids shape[1] on a 1-D tensor).
                 for var_name, in_sh in zip(ins, node.input_shapes):
-                    n = 1
-                    for s in in_sh:
-                        n *= s
-                    if n == target_numel:
+                    if tuple(in_sh) == tuple(node.output_shapes[0]):
                         matching_inp = var_name
                         break
+                # 2. Same numel but different shape: prefer the input with the most
+                #    dimensions so that {inp}.shape[i] references stay in-bounds.
+                #    Example: A_log (64,) vs a (1, 64) — both have numel 64 at B=1,
+                #    but a (1,64) matches the output shape (1,64) better.
+                if matching_inp is None:
+                    best_ndim = -1
+                    for var_name, in_sh in zip(ins, node.input_shapes):
+                        n = 1
+                        for s in in_sh:
+                            n *= s
+                        if n == target_numel and len(in_sh) > best_ndim:
+                            best_ndim = len(in_sh)
+                            matching_inp = var_name
+                # 3. Last resort: highest numel input.
                 if matching_inp is None:
                     best_n = 0
                     for var_name, in_sh in zip(ins, node.input_shapes):

--- a/phew/optimizer.py
+++ b/phew/optimizer.py
@@ -227,13 +227,13 @@ class Optimizer:
                 bottleneck=bottleneck,
                 enabled_subst_classes=self.enabled_subst_classes,
             )
-            graph, sat_stats, egraph, root_expr, node_map, str_node_map = saturator.saturate(graph)
+            graph, sat_stats, egraph, root_exprs, node_map, str_node_map = saturator.saturate(graph)
             search_trace.append(
                 f"  iterations: {sat_stats.iterations}, nodes_before: {sat_stats.nodes_before}"
             )
 
             extractor = Extractor(strategy=self.extraction_strategy)
-            extraction = extractor.extract(egraph, root_expr, node_map, graph, str_node_map)
+            extraction = extractor.extract(egraph, root_exprs, node_map, graph, str_node_map)
             graph = extraction.graph
             search_trace.append(f"  extraction cost: {extraction.cost:.2e} ({extraction.strategy})")
         except ImportError:


### PR DESCRIPTION
## Summary

- **Bug 15 (multi-output / tuple-return)**: `build_egraph` only encoded `graph.outputs[-1]` as the root expression. For functions returning `(y, state)`, the first output was silently dropped — `_GraphReconstructor.build()` then replaced the output list with a single element. Fix encodes all outputs as root expressions, extracts each independently, and reconstructs the full output list via a new `build_multi()` method.
- **Bug 16 (`--fusion` IndexError)**: `_emit_metal_kernel` iterated inputs in order and took the first with matching numel for `output_shapes`/`grid`. When two inputs share numel but differ in rank (e.g. `A_log` shape `(64,)` vs `a` shape `(1, 64)`), the 1-D tensor was picked, producing `kernel.shape[1]` → `IndexError: tuple index out of range` in the emitted Metal kernel call. Fix prefers exact shape match first, then highest ndim, then highest numel.

## Files changed

| File | Change |
|------|--------|
| `phew/egraph/rules_egglog.py` | `build_egraph` now returns `root_exprs: list` (one per output) |
| `phew/egraph/saturation.py` | `saturate()` unpacks and returns `root_exprs` |
| `phew/egraph/extraction.py` | `extract()` accepts `list \| Expr`; new `build_multi()`; `_greedy` loops over all roots |
| `phew/optimizer.py` | Call site updated: `root_expr` → `root_exprs` |
| `phew/emit/codegen.py` | `_emit_metal_kernel` shape-selection priority: exact → most dims → highest numel |

## Test plan

- [x] All 133 existing tests pass (`python -m pytest tests/ -x -q`)
- [x] Smoke test: 2-output graph round-trips through saturation + extraction with both outputs preserved
- [x] Single-output graphs still work (backward-compatible: `root_exprs` wraps a bare `Expr` in a list)

Discovered while optimizing GDN decode in [mlx-lm](https://github.com/ml-explore/mlx-lm) — the `_gated_delta_step` operator returns `(y, state)` and was previously silently losing `y` after optimization.